### PR TITLE
Fix: allow nonleading digits in NSID name segment

### DIFF
--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -699,7 +699,7 @@ mod tests {
     fn valid_nsid() {
         // From https://atproto.com/specs/nsid#examples
         for valid in
-            ["com.example.fooBar", "net.users.bob.ping", "a-0.b-1.c", "a.b.c", "cn.8.lex.stuff"]
+            ["com.example.fooBar", "net.users.bob.ping", "a-0.b-1.c", "a.b.c", "com.example.fooBarV2", "cn.8.lex.stuff"]
         {
             assert!(
                 from_str::<Nsid>(&format!("\"{}\"", valid)).is_ok(),
@@ -712,7 +712,7 @@ mod tests {
     #[test]
     fn invalid_nsid() {
         // From https://atproto.com/specs/nsid#examples
-        for invalid in ["com.exa💩ple.thing", "com.example"] {
+        for invalid in ["com.exa💩ple.thing", "com.example", "com.example.3"] {
             assert!(
                 from_str::<Nsid>(&format!("\"{}\"", invalid)).is_err(),
                 "invalid NSID `{}` parsed as valid",

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -362,7 +362,7 @@ impl Nsid {
         if nsid.len() > 317 {
             Err("NSID too long")
         } else if !RE_NSID
-            .get_or_init(|| Regex::new(r"^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z]{0,61}[a-zA-Z])?)$").unwrap())
+            .get_or_init(|| Regex::new(r"^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z0-9]{0,61}[a-zA-Z0-9])?)$").unwrap())
             .is_match(&nsid)
         {
             Err("Invalid NSID")


### PR DESCRIPTION
A few months ago, the spec was updated to the relax NSID syntax for the `name` (last) segment of NSIDs: non-leading digits are now permitted: https://github.com/bluesky-social/atproto-website/pull/402

This change adds the new examples from the updated spec to the tests, and passes those test by adding `0-9` to the middle and end `[]` groups of the NSID regex.

This is a minimal change to pass the tests, but the `name` segment matcher could be further simplified:

```regex
(\.[a-zA-Z]([a-zA-Z]{0,61}[a-zA-Z])?)  # before
(\.[a-zA-Z]([a-zA-Z0-9]{0,61}[a-zA-Z0-9])?)  # this PR
(\.[a-zA-Z][a-zA-Z0-9]{0,62})  # PR-equivalent except internal capture group
```

but that refactor is kind of to taste. happy to update the PR if you like it. as-is this PR has a bit more pattern consistency with the earlier segment matchers.