### PR TITLE
fix: Update Cargo.toml for pinning version of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "atrium-common",
  "atrium-xrpc-client",
  "chrono",
+ "idna_adapter",
  "ipld-core",
  "litemap",
  "native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ trait-variant = "0.1.2"
 
 # Others
 base64ct = "=1.6.0"
+idna_adapter = "=1.2.0"
 litemap = "=0.7.4"
 native-tls = "=0.2.13"
 zerofrom = "=0.1.5"

--- a/bsky-sdk/Cargo.toml
+++ b/bsky-sdk/Cargo.toml
@@ -30,8 +30,9 @@ atrium-common.workspace = true
 ipld-core.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
-native-tls.workspace = true
+idna_adapter.workspace = true
 litemap.workspace = true
+native-tls.workspace = true
 zerofrom.workspace = true
 
 [features]


### PR DESCRIPTION
The build is failing because `idna_adapter 1.2.1` is now MSRV `v1.82.0`.
https://crates.io/crates/idna_adapter/1.2.1
https://github.com/atrium-rs/atrium/actions/runs/15243312262/job/42866108279#step:4:349

---

This pull request introduces a new dependency, `idna_adapter`, to the project and updates its usage in the workspace configuration. The changes ensure consistency across the dependency management files.

### Dependency Management Updates:

* Added `idna_adapter = "=1.2.0"` to the dependencies in `Cargo.toml` to include the new library in the project.
* Updated the workspace configuration in `bsky-sdk/Cargo.toml` to include `idna_adapter` while maintaining `native-tls` and other dependencies.