### PR TITLE
fix: Improve error handling in types conversion

### DIFF
--- a/atrium-api/src/error.rs
+++ b/atrium-api/src/error.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 pub enum Error {
     #[error(transparent)]
     IpldCoreSerde(#[from] ipld_core::serde::SerdeError),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
     #[error("not allowed in ATProtocol")]
     NotAllowed,
 }

--- a/atrium-api/src/types.rs
+++ b/atrium-api/src/types.rs
@@ -276,7 +276,7 @@ where
         //
         // For the time being, until this problem is resolved, use the workaround of serializing once to a json string and then deserializing it.
         let json = serde_json::to_vec(&value).unwrap();
-        Ok(serde_json::from_slice(&json).unwrap())
+        Ok(serde_json::from_slice(&json)?)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add SerdeJson error variant to Error enum
- Replace unwrap() with proper error propagation in try_from_unknown

## Related Issues
ref #319

## Details
This change improves error diagnostics by replacing unwrap() with proper error propagation in the `try_from_unknown` function. While this doesn't directly fix the malformed date parsing issue reported in #319, it makes debugging easier by surfacing the actual errors instead of panicking.

The specific improvements:
1. Added `SerdeJson(#[from] serde_json::Error)` variant to the Error enum
2. Replaced `serde_json::from_slice(&json).unwrap()` with `serde_json::from_slice(&json)?` in types.rs:279

This will help identify and debug issues like malformed dates from the BlueSky API by providing proper error messages instead of panic.