### PR TITLE
fix: Add explicit lifetime annotation to Language::as_ref return type

### DIFF
--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -404,7 +404,7 @@ impl Language {
 
     /// Returns a [`LanguageTag`] referencing this tag.
     #[inline]
-    pub fn as_ref(&self) -> LanguageTag {
+    pub fn as_ref(&self) -> LanguageTag<'_> {
         self.0.as_ref()
     }
 }


### PR DESCRIPTION
## Summary
- Fixes lifetime elision warning that became an error in recent stable Rust versions
- Adds explicit lifetime annotation to `Language::as_ref()` return type

## Background
This resolves a CI failure where the "Rust (stable)" job was failing due to a confusing lifetime elision warning in `atrium-api/src/types/string.rs`. The issue was that the `as_ref()` method returned `LanguageTag` without an explicit lifetime parameter, which recent stable Rust compilers flag as potentially confusing.

## Changes
```rust
// Before:
pub fn as_ref(&self) -> LanguageTag {

// After:  
pub fn as_ref(&self) -> LanguageTag<'_> {
```

## Test Plan
- [x] `cargo +stable check` passes
- [x] Existing tests continue to pass
- [x] No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.ai/code)