### PR TITLE
fix: Remove duplicate headers and fix ordering in CHANGELOGs

### DIFF
--- a/atrium-api/CHANGELOG.md
+++ b/atrium-api/CHANGELOG.md
@@ -7,24 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.25.5](https://github.com/atrium-rs/atrium/compare/atrium-api-v0.25.4...atrium-api-v0.25.5) - 2025-08-16
-
-### Fixed
-
-- Add explicit lifetime annotation to Language::as_ref return type ([#323](https://github.com/atrium-rs/atrium/pull/323))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.25.6](https://github.com/atrium-rs/atrium/compare/atrium-api-v0.25.5...atrium-api-v0.25.6) - 2025-10-01
 
 ### Other
 
 - Update for latest lexicon ([#327](https://github.com/atrium-rs/atrium/pull/327))
+
+## [0.25.5](https://github.com/atrium-rs/atrium/compare/atrium-api-v0.25.4...atrium-api-v0.25.5) - 2025-08-16
+
+### Fixed
+
+- Add explicit lifetime annotation to Language::as_ref return type ([#323](https://github.com/atrium-rs/atrium/pull/323))
 
 ## [0.25.4](https://github.com/atrium-rs/atrium/compare/atrium-api-v0.25.3...atrium-api-v0.25.4) - 2025-05-25
 

--- a/atrium-repo/CHANGELOG.md
+++ b/atrium-repo/CHANGELOG.md
@@ -7,24 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5](https://github.com/atrium-rs/atrium/compare/atrium-repo-v0.1.4...atrium-repo-v0.1.5) - 2025-08-16
-
-### Other
-
-- updated the following local packages: atrium-api, atrium-api
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.1.6](https://github.com/atrium-rs/atrium/compare/atrium-repo-v0.1.5...atrium-repo-v0.1.6) - 2025-10-01
 
 ### Fixed
 
 - Apply clippy suggestions and skip stable clippy in CI ([#330](https://github.com/atrium-rs/atrium/pull/330))
+
+## [0.1.5](https://github.com/atrium-rs/atrium/compare/atrium-repo-v0.1.4...atrium-repo-v0.1.5) - 2025-08-16
+
+### Other
+
+- updated the following local packages: atrium-api, atrium-api
 
 ## [0.1.4](https://github.com/atrium-rs/atrium/compare/atrium-repo-v0.1.3...atrium-repo-v0.1.4) - 2025-05-25
 

--- a/bsky-cli/CHANGELOG.md
+++ b/bsky-cli/CHANGELOG.md
@@ -7,24 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.34](https://github.com/atrium-rs/atrium/compare/bsky-cli-v0.1.33...bsky-cli-v0.1.34) - 2025-08-16
-
-### Other
-
-- updated the following local packages: bsky-sdk
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.1.35](https://github.com/atrium-rs/atrium/compare/bsky-cli-v0.1.34...bsky-cli-v0.1.35) - 2025-10-01
 
 ### Other
 
 - Update for latest lexicon ([#327](https://github.com/atrium-rs/atrium/pull/327))
+
+## [0.1.34](https://github.com/atrium-rs/atrium/compare/bsky-cli-v0.1.33...bsky-cli-v0.1.34) - 2025-08-16
+
+### Other
+
+- updated the following local packages: bsky-sdk
 
 ## [0.1.33](https://github.com/atrium-rs/atrium/compare/bsky-cli-v0.1.32...bsky-cli-v0.1.33) - 2025-05-25
 

--- a/bsky-sdk/CHANGELOG.md
+++ b/bsky-sdk/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.21](https://github.com/atrium-rs/atrium/compare/bsky-sdk-v0.1.20...bsky-sdk-v0.1.21) - 2025-08-16
-
-### Other
-
-- updated the following local packages: atrium-api
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.1.22](https://github.com/atrium-rs/atrium/compare/bsky-sdk-v0.1.21...bsky-sdk-v0.1.22) - 2025-10-01
 
 ### Fixed
@@ -29,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Update for latest lexicon ([#327](https://github.com/atrium-rs/atrium/pull/327))
+
+## [0.1.21](https://github.com/atrium-rs/atrium/compare/bsky-sdk-v0.1.20...bsky-sdk-v0.1.21) - 2025-08-16
+
+### Other
+
+- updated the following local packages: atrium-api
 
 ## [0.1.20](https://github.com/atrium-rs/atrium/compare/bsky-sdk-v0.1.19...bsky-sdk-v0.1.20) - 2025-05-25
 


### PR DESCRIPTION
## Summary

Fixes CHANGELOG corruption that was introduced in #324 (release-plz-2025-08-15T07-33-21Z).

### Issues Fixed
- **Duplicate headers**: The release-plz PR incorrectly inserted complete header blocks (from `# Changelog` to `## [Unreleased]`) into 4 CHANGELOG files, causing duplicate headers
- **Incorrect ordering**: Version entries were in wrong order (older versions appearing before newer ones, violating Keep a Changelog format)

### Changes Made
- Removed duplicate header sections from:
  - `atrium-api/CHANGELOG.md` (v0.25.5 and v0.25.6)
  - `bsky-sdk/CHANGELOG.md` (v0.1.21 and v0.1.22)
  - `atrium-repo/CHANGELOG.md` (v0.1.5 and v0.1.6)
  - `bsky-cli/CHANGELOG.md` (v0.1.34 and v0.1.35)
- Reordered version entries so newest versions appear first (as per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) standard)

### Root Cause
The release-plz automated PR (#324) incorrectly prepended entire header blocks instead of just inserting new version entries after the existing `## [Unreleased]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)