### PR TITLE
fix(codegen): support permission-set, keyword properties, and record refs

### DIFF
--- a/lexicon/atrium-codegen/src/generator.rs
+++ b/lexicon/atrium-codegen/src/generator.rs
@@ -22,6 +22,13 @@ pub(crate) fn generate_schemas(
     outdir: &Path,
 ) -> Result<Vec<PathBuf>, Box<dyn Error>> {
     let mut results = Vec::new();
+    // `permission-set` defs describe OAuth scopes, not API data types, so they produce
+    // no Rust types. Skip schemas that only define permission sets (e.g. `app.bsky.auth*`).
+    if !schema.defs.is_empty()
+        && schema.defs.values().all(|def| matches!(def, LexUserType::PermissionSet(_)))
+    {
+        return Ok(results);
+    }
     let mut paths = schema.id.split('.').collect::<Vec<_>>();
     if let Some(basename) = paths.pop() {
         let mut tokens = Vec::new();
@@ -87,6 +94,7 @@ pub(crate) fn generate_records(
 ) -> Result<PathBuf, Box<dyn Error>> {
     let records = schemas
         .iter()
+        .filter(|schema| namespaces.iter().any(|(prefix, _)| schema.id.starts_with(prefix)))
         .filter_map(|schema| {
             if let Some(LexUserType::Record(_)) = schema.defs.get("main") {
                 Some(schema.id.clone())
@@ -116,6 +124,9 @@ pub(crate) fn generate_client(
     let mut schema_map = HashMap::new();
     let mut tree = HashMap::new();
     for schema in schemas {
+        if !namespaces.iter().any(|(prefix, _)| schema.id.starts_with(prefix)) {
+            continue;
+        }
         if let Some(def) = schema.defs.get("main") {
             if matches!(
                 def,

--- a/lexicon/atrium-codegen/src/lib.rs
+++ b/lexicon/atrium-codegen/src/lib.rs
@@ -23,12 +23,18 @@ pub fn genapi(
     for path in &paths {
         schemas.push(from_reader::<_, LexiconDoc>(File::open(path)?)?);
     }
+    // Register record NSIDs so refs to a record's `#main` resolve to `Record`, not `Main`.
+    let record_nsids = schemas
+        .iter()
+        .filter(|schema| {
+            matches!(schema.defs.get("main"), Some(atrium_lex::lexicon::LexUserType::Record(_)))
+        })
+        .map(|schema| schema.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    token_stream::set_record_nsids(record_nsids);
     let mut results = Vec::new();
     for &(prefix, _) in namespaces {
-        let targets = schemas
-            .iter()
-            .filter(|schema| schema.id.starts_with(prefix))
-            .collect_vec();
+        let targets = schemas.iter().filter(|schema| schema.id.starts_with(prefix)).collect_vec();
         results.extend(gen(&outdir, &targets)?);
     }
     results.push(generate_records(&outdir, &schemas, namespaces)?);

--- a/lexicon/atrium-codegen/src/token_stream.rs
+++ b/lexicon/atrium-codegen/src/token_stream.rs
@@ -1,9 +1,10 @@
 use atrium_lex::lexicon::*;
 use heck::{ToPascalCase, ToShoutySnakeCase, ToSnakeCase};
 use itertools::Itertools;
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 use syn::{Path, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,6 +12,46 @@ enum OutputType {
     None,
     Data,
     Bytes,
+}
+
+/// NSIDs whose `main` def is a `record`. Populated once via [`set_record_nsids`]
+/// before generation so refs to a record's `#main` resolve to the generated
+/// `Record` type rather than the (non-existent) `Main`.
+static RECORD_NSIDS: OnceLock<HashSet<String>> = OnceLock::new();
+
+/// Register the set of record NSIDs. Call once before generating any schema.
+pub fn set_record_nsids(nsids: HashSet<String>) {
+    let _ = RECORD_NSIDS.set(nsids);
+}
+
+fn is_record_nsid(nsid: &str) -> bool {
+    RECORD_NSIDS.get().is_some_and(|set| set.contains(nsid))
+}
+
+/// Build an identifier from an already-cased name, using a raw identifier
+/// (`r#name`) when the name collides with a Rust keyword (e.g. `match`, `type`, `ref`).
+fn escaped_ident(name: &str) -> Ident {
+    if is_rust_keyword(name) {
+        format_ident!("r#{}", name)
+    } else {
+        format_ident!("{}", name)
+    }
+}
+
+/// Rust keywords that are valid as raw identifiers. Excludes `crate`/`self`/`Self`/`super`,
+/// which cannot be raw identifiers (they do not occur as Lexicon property names).
+fn is_rust_keyword(s: &str) -> bool {
+    matches!(
+        s,
+        // strict keywords
+        "as" | "break" | "const" | "continue" | "dyn" | "else" | "enum" | "extern" | "false"
+            | "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" | "match" | "mod" | "move"
+            | "mut" | "pub" | "ref" | "return" | "static" | "struct" | "trait" | "true" | "type"
+            | "unsafe" | "use" | "where" | "while" | "async" | "await"
+            // reserved keywords
+            | "abstract" | "become" | "box" | "do" | "final" | "gen" | "macro" | "override"
+            | "priv" | "typeof" | "unsized" | "virtual" | "yield" | "try"
+    )
 }
 
 pub fn user_type(
@@ -28,6 +69,8 @@ pub fn user_type(
         LexUserType::Token(token) => lex_token(token, name, schema_id)?,
         LexUserType::Object(object) => lex_object(object, if is_main { "Main" } else { name })?,
         LexUserType::String(string) => lex_string(string, name)?,
+        // `permission-set` defs describe OAuth scopes, not API data types; emit nothing.
+        LexUserType::PermissionSet(_) => quote!(),
         _ => unimplemented!("{def:?}"),
     };
     Ok(quote! {
@@ -306,10 +349,7 @@ fn lex_object_property(
         LexObjectProperty::String(string) => string_type(string)?,
         LexObjectProperty::Unknown(unknown) => unknown_type(unknown)?,
     };
-    let field_name = format_ident!(
-        "{}",
-        if name == "ref" || name == "type" { format!("r#{name}") } else { name.to_snake_case() }
-    );
+    let field_name = escaped_ident(&name.to_snake_case());
     let mut attributes = match property {
         LexObjectProperty::Bytes(_) => {
             let default = if is_required { quote!() } else { quote!(#[serde(default)]) };
@@ -1021,6 +1061,13 @@ fn derives() -> Result<TokenStream> {
 
 fn resolve_path(r#ref: &str, default: &str) -> Result<TokenStream> {
     let (namespace, def) = r#ref.split_once('#').unwrap_or((r#ref, default));
+    // A ref to a record's `#main` must resolve to the generated `Record` type
+    // (records generate `Record`/`RecordData`); only objects generate `Main`.
+    let def = if def == "main" && !namespace.is_empty() && is_record_nsid(namespace) {
+        "record"
+    } else {
+        def
+    };
     let path = syn::parse_str::<Path>(&if namespace.is_empty() {
         def.to_pascal_case()
     } else {

--- a/lexicon/atrium-lex/src/lexicon.rs
+++ b/lexicon/atrium-lex/src/lexicon.rs
@@ -313,6 +313,30 @@ pub struct LexRecord {
     pub record: LexRecordRecord,
 }
 
+// permissions (OAuth scopes)
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LexPermission {
+    pub resource: String,
+    pub action: Option<Vec<String>>,
+    pub collection: Option<Vec<String>>,
+    pub lxm: Option<Vec<String>>,
+    pub inherit_aud: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LexPermissionSet {
+    pub description: Option<String>,
+    pub title: Option<String>,
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub permissions: Vec<LexPermission>,
+}
+
 // core
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -335,6 +359,8 @@ pub enum LexUserType {
     Array(LexArray),
     // lexToken
     Token(LexToken),
+    // lexPermissionSet (OAuth permission scopes; not an API data type)
+    PermissionSet(LexPermissionSet),
     // lexObject
     Object(LexObject),
     // lexBoolean,


### PR DESCRIPTION
## Summary

`atrium-codegen` / `atrium-lex` have fallen behind the lexicon spec: running `lexgen` against the current [`bluesky-social/atproto`](https://github.com/bluesky-social/atproto) lexicons either panics or emits non-compiling code. This PR makes the four minimal changes needed to regenerate `atrium-api` cleanly against the latest lexicons with no manual post-edits.

These are additive/robustness changes — they generalize existing special-cases and add handling for constructs that previously weren't supported. Generated output for lexicons that already worked is unchanged.

## Changes

- **`atrium-lex`: add the `permission-set` user type.** Skip permission-set-only schemas during generation (e.g. `app.bsky.auth*`), since they describe OAuth scopes rather than API data types and produce no Rust types.
- **Escape Rust keywords used as object property names** via raw identifiers (e.g. `match` → `r#match`), generalizing the previous `ref`/`type` special-case to all keywords.
- **Resolve a ref to a record's `#main` to the generated `Record` type** instead of the non-existent `Main` (e.g. `com.atproto.lexicon.resolveLexicon` referencing the `com.atproto.lexicon.schema` record).
- **Restrict the `record.rs` / `client.rs` aggregations to the configured namespaces**, so out-of-scope lexicons that ship in the atproto repo (`site.standard`, `internal.bsky`, `com.germnetwork`, …) don't produce references to ungenerated modules.

## Verification

Regenerated `atrium-api` against `bluesky-social/atproto@3247279`: `lexgen` succeeds and `cargo build -p atrium-api --all-features` passes with **no manual edits**. The resulting generated crate is in production use in downstream services (a firehose indexer and an API gateway).

I've intentionally kept this PR to the **codegen changes only** — the regeneration cadence and versioning are yours to drive. The full regen this unblocks (≈146 files) lives on my fork as a reference if useful, but isn't included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
